### PR TITLE
Enhancement: review job update

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: 17
 
       - name: Set up Gradle Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}


### PR DESCRIPTION
- updated actions/cache to v3 to support node 16 instead of node 12, based on this [annotation message](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/) from previously ran action