### PR TITLE
Chore: update android gradle plugin and kotlin version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,7 +116,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"
+        kotlinCompilerExtensionVersion = "1.5.9"
     }
 
     packaging {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,12 +7,12 @@ buildscript {
 } // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.1.3" apply false
-    id("com.android.library") version "8.1.3" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
-    id("com.google.devtools.ksp") version "1.9.10-1.0.13" apply false
+    id("com.android.application") version "8.2.2" apply false
+    id("com.android.library") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
 
-    id("com.google.dagger.hilt.android") version "2.48" apply false
+    id("com.google.dagger.hilt.android") version "2.48.1" apply false
     id("org.jlleitschuh.gradle.ktlint") version "12.1.0" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.4" apply false
     id("de.mannodermaus.android-junit5") version "1.9.3.0" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.nonTransitiveRClass=true
 
 # Use latest lint alpha for best available K2 support
 # https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
-android.experimental.lint.version=8.4.0-alpha09
+android.experimental.lint.version=8.4.0-alpha10
 
 # Use K2 compiler
 # Updated to stable release once available

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 05 02:03:18 PST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- upgrade android gradle tools version to 8.2.2
- upgrade kotlin version to 1.9.22
- upgrade devtools.ksp version as a needed adjustment from kotlin version upgrade
- upgrade dagger hilt version to 2.48.1
- upgrade compose compiler as a needed adjustment from kotlin version upgrade