### PR TITLE
Chore: update compose and material dependency versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ val localProperties = Properties()
 localProperties.load(project.rootProject.file("local.properties").inputStream())
 
 // Dependencies Extensions - this will be migrated via version catalog
-val composeVersion = "1.6.1"
+val composeVersion = "1.6.3"
 val roomVersion = "2.6.0"
 val hiltVersion = "2.48"
 
@@ -146,7 +146,7 @@ fun getVersionCode(): Int {
 
 dependencies {
     implementation("androidx.compose.ui:ui:$composeVersion")
-    implementation("androidx.compose.material3:material3:1.2.0")
+    implementation("androidx.compose.material3:material3:1.2.1")
     implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
@@ -164,7 +164,7 @@ dependencies {
 
     // Hilt dependencies
     implementation("com.google.dagger:hilt-android:$hiltVersion")
-    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     ksp("com.google.dagger:hilt-android-compiler:$hiltVersion")
 
     // Retrofit


### PR DESCRIPTION
- update compose from 1.6.2 to 1.6.3
- update hilt-navigation-compose from 1.1.0 to 1.2.0
- update material3 from 1.2.0 to 1.2.1