### PR TITLE
Feature: implement onboarding process data layer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,4 @@ root = true
 
 [*.{kt,kts}]
 ktlint_function_naming_ignore_when_annotated_with = Composable
-
-# disable below once fully working with classes that have hilt annotations
-# read insights: https://github.com/pinterest/ktlint/issues/2138
-# ktlint_standard_annotation = disabled
+ktlint_standard_annotation = disabled

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ val localProperties = Properties()
 localProperties.load(project.rootProject.file("local.properties").inputStream())
 
 // Dependencies Extensions - this will be migrated via version catalog
-val composeVersion = "1.6.2"
+val composeVersion = "1.6.3"
 val roomVersion = "2.6.0"
 val hiltVersion = "2.48"
 
@@ -146,7 +146,7 @@ fun getVersionCode(): Int {
 
 dependencies {
     implementation("androidx.compose.ui:ui:$composeVersion")
-    implementation("androidx.compose.material3:material3:1.2.0")
+    implementation("androidx.compose.material3:material3:1.2.1")
     implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
@@ -164,7 +164,7 @@ dependencies {
 
     // Hilt dependencies
     implementation("com.google.dagger:hilt-android:$hiltVersion")
-    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     ksp("com.google.dagger:hilt-android-compiler:$hiltVersion")
 
     // Retrofit

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ localProperties.load(project.rootProject.file("local.properties").inputStream())
 // Dependencies Extensions - this will be migrated via version catalog
 val composeVersion = "1.6.3"
 val roomVersion = "2.6.0"
-val hiltVersion = "2.48"
+val hiltVersion = "2.51"
 
 android {
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,6 +162,9 @@ dependencies {
     // Navigation Compose
     implementation("androidx.navigation:navigation-compose:2.7.7")
 
+    // Preferences Datastore
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+
     // Hilt dependencies
     implementation("com.google.dagger:hilt-android:$hiltVersion")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")

--- a/app/src/main/java/com/dailyscoop/app/MainActivity.kt
+++ b/app/src/main/java/com/dailyscoop/app/MainActivity.kt
@@ -3,22 +3,41 @@ package com.dailyscoop.app
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.rememberNavController
+import com.dailyscoop.app.feature.home.navigation.HOME_ROUTE
+import com.dailyscoop.app.feature.onboarding.navigation.ONBOARDING_ROUTE
 import com.dailyscoop.app.ui.DailyScoopApp
 import com.dailyscoop.app.ui.theme.DailyScoopTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private val viewModel: MainVM by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         // TODOs: splash screen implementation will be improved once integrated with auth feature
-        installSplashScreen()
+        installSplashScreen().apply {
+            setKeepOnScreenCondition(condition = {
+                viewModel.shouldShowSplashScreen.value
+            })
+        }
 
         setContent {
+            val isAppFirstLaunch = viewModel.isAppFirstLaunch.collectAsStateWithLifecycle()
+
             DailyScoopTheme {
-                DailyScoopApp()
+                val mainNavController = rememberNavController()
+                val appEntryStartDestination = if (isAppFirstLaunch.value) ONBOARDING_ROUTE else HOME_ROUTE
+
+                DailyScoopApp(
+                    navController = mainNavController,
+                    startDestination = appEntryStartDestination,
+                )
             }
         }
     }

--- a/app/src/main/java/com/dailyscoop/app/MainVM.kt
+++ b/app/src/main/java/com/dailyscoop/app/MainVM.kt
@@ -5,40 +5,58 @@ package com.dailyscoop.app
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.dailyscoop.app.data.repositories.INewsRepository
+import com.dailyscoop.app.data.repositories.UserPreferencesRepository
 import com.dailyscoop.app.model.Article
 import com.dailyscoop.app.model.Headline
 import com.dailyscoop.app.utilities.Result
 import com.dailyscoop.app.utilities.asResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
-class MainVM
-    @Inject
-    constructor(
-        newsRepository: INewsRepository,
-    ) : ViewModel() {
-        val newsUiState: StateFlow<NewsUiState> =
-            newsUiState(
-                newsRepository = newsRepository,
-            ).stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5_000),
-                initialValue = NewsUiState.Loading,
-            )
+class MainVM @Inject constructor(
+    newsRepository: INewsRepository,
+    userPreferencesRepository: UserPreferencesRepository,
+) : ViewModel() {
+    private val _shouldShowSplashScreen = MutableStateFlow(true)
+    val shouldShowSplashScreen: StateFlow<Boolean> = _shouldShowSplashScreen
 
-        val articleUiState: StateFlow<ArticleUiState> =
-            articleUiState(newsRepository).stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5_000),
-                initialValue = ArticleUiState.Loading,
-            )
+    private val _isAppFirstLaunch = MutableStateFlow(false)
+    val isAppFirstLaunch: StateFlow<Boolean> = _isAppFirstLaunch
+
+    init {
+        userPreferencesRepository.getIsAppFirstLaunch().onEach {
+            _isAppFirstLaunch.value = it
+            delay(300) // Without this delay, the home screen will be shown for a momentum.
+            _shouldShowSplashScreen.value = false
+        }.launchIn(viewModelScope)
     }
+
+    val newsUiState: StateFlow<NewsUiState> =
+        newsUiState(
+            newsRepository = newsRepository,
+        ).stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = NewsUiState.Loading,
+        )
+
+    val articleUiState: StateFlow<ArticleUiState> =
+        articleUiState(newsRepository).stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = ArticleUiState.Loading,
+        )
+}
 
 private fun articleUiState(newsRepository: INewsRepository): Flow<ArticleUiState> {
     /**

--- a/app/src/main/java/com/dailyscoop/app/data/repositories/IUserPreferencesRepository.kt
+++ b/app/src/main/java/com/dailyscoop/app/data/repositories/IUserPreferencesRepository.kt
@@ -1,0 +1,21 @@
+package com.dailyscoop.app.data.repositories
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * This interface defines methods for accessing and modifying user preferences through a repository layer.
+ * The repository layer can potentially handle additional logic or data transformations related to user preferences.
+ */
+interface IUserPreferencesRepository {
+    /**
+     * Stores a boolean value indicating whether this is the first app use/launch.
+     * @param value True if it's the first launch, false otherwise.
+     */
+    suspend fun setIsAppFirstLaunch(value: Boolean)
+
+    /**
+     * Retrieves a flow of boolean values indicating whether this is the first app launch.
+     * @return Flow of boolean values. The behavior related to default values might depend on the implementation.
+     */
+    fun getIsAppFirstLaunch(): Flow<Boolean>
+}

--- a/app/src/main/java/com/dailyscoop/app/data/repositories/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/dailyscoop/app/data/repositories/UserPreferencesRepository.kt
@@ -1,0 +1,17 @@
+package com.dailyscoop.app.data.repositories
+
+import com.dailyscoop.app.data.source.datastore.IUserPreferencesDatastore
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class UserPreferencesRepository @Inject constructor(
+    private val userPreferencesDataSource: IUserPreferencesDatastore,
+) : IUserPreferencesRepository {
+    override suspend fun setIsAppFirstLaunch(value: Boolean) {
+        userPreferencesDataSource.setIsAppFirstLaunch(value)
+    }
+
+    override fun getIsAppFirstLaunch(): Flow<Boolean> {
+        return userPreferencesDataSource.getIsAppFirstLaunch()
+    }
+}

--- a/app/src/main/java/com/dailyscoop/app/data/source/datastore/IUserPreferencesDatastore.kt
+++ b/app/src/main/java/com/dailyscoop/app/data/source/datastore/IUserPreferencesDatastore.kt
@@ -1,0 +1,20 @@
+package com.dailyscoop.app.data.source.datastore
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * This interface defines methods for accessing and modifying user preferences using Preferences DataStore.
+ */
+interface IUserPreferencesDatastore {
+    /**
+     * Stores a boolean value indicating whether this is the first app launch.
+     * @param value True if it's the first launch, false otherwise.
+     */
+    suspend fun setIsAppFirstLaunch(value: Boolean)
+
+    /**
+     * Retrieves a flow of boolean values indicating whether this is the first app launch.
+     * @return Flow of boolean values. By default, it returns true if the key doesn't exist.
+     */
+    fun getIsAppFirstLaunch(): Flow<Boolean>
+}

--- a/app/src/main/java/com/dailyscoop/app/data/source/datastore/UserPreferencesDatastore.kt
+++ b/app/src/main/java/com/dailyscoop/app/data/source/datastore/UserPreferencesDatastore.kt
@@ -1,0 +1,28 @@
+package com.dailyscoop.app.data.source.datastore
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import com.dailyscoop.app.utilities.manager.PreferencesDatastoreManager
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class UserPreferencesDatastore @Inject constructor(
+    private val datastoreManager: PreferencesDatastoreManager,
+) : IUserPreferencesDatastore {
+    override suspend fun setIsAppFirstLaunch(value: Boolean) {
+        datastoreManager.store(
+            preferenceKey = IS_APP_FIRST_LAUNCH,
+            value = value,
+        )
+    }
+
+    override fun getIsAppFirstLaunch(): Flow<Boolean> {
+        return datastoreManager.retrieve(
+            preferenceKey = IS_APP_FIRST_LAUNCH,
+            defaultValue = true,
+        )
+    }
+
+    companion object {
+        private val IS_APP_FIRST_LAUNCH = booleanPreferencesKey("is_app_first_launch")
+    }
+}

--- a/app/src/main/java/com/dailyscoop/app/di/DataRepositoryModule.kt
+++ b/app/src/main/java/com/dailyscoop/app/di/DataRepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.dailyscoop.app.di
 
 import com.dailyscoop.app.data.repositories.INewsRepository
+import com.dailyscoop.app.data.repositories.IUserPreferencesRepository
 import com.dailyscoop.app.data.repositories.NewsRepository
+import com.dailyscoop.app.data.repositories.UserPreferencesRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -9,7 +11,10 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-interface DataModule {
+interface DataRepositoryModule {
     @Binds
     fun bindNewsRepository(newsRepository: NewsRepository): INewsRepository
+
+    @Binds
+    fun bindUserPreferencesRepository(userPreferencesRepository: UserPreferencesRepository): IUserPreferencesRepository
 }

--- a/app/src/main/java/com/dailyscoop/app/di/DataSourceModule.kt
+++ b/app/src/main/java/com/dailyscoop/app/di/DataSourceModule.kt
@@ -1,5 +1,7 @@
 package com.dailyscoop.app.di
 
+import com.dailyscoop.app.data.source.datastore.IUserPreferencesDatastore
+import com.dailyscoop.app.data.source.datastore.UserPreferencesDatastore
 import com.dailyscoop.app.data.source.local.INewsLocalDataSource
 import com.dailyscoop.app.data.source.local.NewsLocalDataSource
 import com.dailyscoop.app.data.source.remote.INewsNetworkDataSource
@@ -17,4 +19,7 @@ interface DataSourceModule {
 
     @Binds
     fun bindNewsLocalDataSource(newsLocalDataSource: NewsLocalDataSource): INewsLocalDataSource
+
+    @Binds
+    fun bindUserPreferencesDataStore(userPreferencesDatastore: UserPreferencesDatastore): IUserPreferencesDatastore
 }

--- a/app/src/main/java/com/dailyscoop/app/di/DataStoreModule.kt
+++ b/app/src/main/java/com/dailyscoop/app/di/DataStoreModule.kt
@@ -1,0 +1,34 @@
+package com.dailyscoop.app.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private const val DAILYSCOOP_DATASTORE_PREFERENCES = "dailyscoop_datastore_preferences"
+
+@InstallIn(SingletonComponent::class)
+@Module
+object DataStoreModule {
+    @Singleton
+    @Provides
+    fun providePreferencesDataStore(
+        @ApplicationContext appContext: Context,
+    ): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+            migrations = listOf(SharedPreferencesMigration(appContext, DAILYSCOOP_DATASTORE_PREFERENCES)),
+            produceFile = { appContext.preferencesDataStoreFile(DAILYSCOOP_DATASTORE_PREFERENCES) },
+        )
+    }
+}

--- a/app/src/main/java/com/dailyscoop/app/feature/onboarding/OnboardingScreenItem.kt
+++ b/app/src/main/java/com/dailyscoop/app/feature/onboarding/OnboardingScreenItem.kt
@@ -27,4 +27,4 @@ enum class OnboardingScreenItem(
 /**
  * List of onboarding screen features that can be utilized within the app
  */
-val onboardingScreenItems: List<OnboardingScreenItem> = OnboardingScreenItem.entries
+val onboardingScreenEntries: List<OnboardingScreenItem> = OnboardingScreenItem.entries

--- a/app/src/main/java/com/dailyscoop/app/feature/onboarding/OnboardingVM.kt
+++ b/app/src/main/java/com/dailyscoop/app/feature/onboarding/OnboardingVM.kt
@@ -1,0 +1,19 @@
+package com.dailyscoop.app.feature.onboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.dailyscoop.app.data.repositories.IUserPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingVM @Inject constructor(
+    private val userPreferencesRepository: IUserPreferencesRepository,
+) : ViewModel() {
+    fun setIsAppFirstLaunch(value: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setIsAppFirstLaunch(value)
+        }
+    }
+}

--- a/app/src/main/java/com/dailyscoop/app/navigation/DailyScoopNavHost.kt
+++ b/app/src/main/java/com/dailyscoop/app/navigation/DailyScoopNavHost.kt
@@ -12,9 +12,9 @@ import com.dailyscoop.app.feature.search.navigation.searchScreen
 
 @Composable
 fun DailyScoopNavHost(
-    modifier: Modifier = Modifier,
     navController: NavHostController,
     startDestination: String,
+    modifier: Modifier = Modifier,
 ) {
     NavHost(
         navController = navController,

--- a/app/src/main/java/com/dailyscoop/app/ui/DailyScoopApp.kt
+++ b/app/src/main/java/com/dailyscoop/app/ui/DailyScoopApp.kt
@@ -8,9 +8,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
-import com.dailyscoop.app.feature.home.navigation.HOME_ROUTE
 import com.dailyscoop.app.feature.onboarding.navigation.ONBOARDING_ROUTE
 import com.dailyscoop.app.navigation.DailyScoopNavHost
 import com.dailyscoop.app.navigation.topLevelDestinations
@@ -18,17 +17,16 @@ import com.dailyscoop.app.ui.components.DailyScoopBottomBar
 import com.dailyscoop.app.utilities.navigateToMainLevelDestinationRoute
 
 @Composable
-fun DailyScoopApp() {
-    val navController = rememberNavController()
+fun DailyScoopApp(
+    navController: NavHostController,
+    startDestination: String,
+) {
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = currentBackStackEntry?.destination
 
-    // TODO - remove this when working for data layer integration needed for onboarding screen feature
-    val isAppFirstUse = true
-
     Scaffold(
         bottomBar = {
-            if (!isAppFirstUse) {
+            if (startDestination != ONBOARDING_ROUTE) {
                 DailyScoopBottomBar(
                     destinations = topLevelDestinations,
                     currentDestination = currentDestination,
@@ -39,13 +37,12 @@ fun DailyScoopApp() {
         },
     ) { scaffoldPadding ->
         Surface(
-            modifier = Modifier,
             color = MaterialTheme.colorScheme.background,
         ) {
             DailyScoopNavHost(
                 navController = navController,
                 modifier = Modifier.padding(scaffoldPadding),
-                startDestination = if (isAppFirstUse) ONBOARDING_ROUTE else HOME_ROUTE,
+                startDestination = startDestination,
             )
         }
     }

--- a/app/src/main/java/com/dailyscoop/app/utilities/manager/PreferencesDatastoreManager.kt
+++ b/app/src/main/java/com/dailyscoop/app/utilities/manager/PreferencesDatastoreManager.kt
@@ -1,0 +1,52 @@
+package com.dailyscoop.app.utilities.manager
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * This manager class provides methods for managing user preferences using Preferences DataStore.
+ * It offers functionalities to store, clear, and retrieve data associated with specific preference keys.
+ */
+class PreferencesDatastoreManager @Inject constructor(
+    private val datastore: DataStore<Preferences>,
+) {
+    /**
+     * Retrieves value from preferences datastore
+     * @param preferenceKey - key value assigned to be retrieved
+     */
+    fun <T> retrieve(
+        preferenceKey: Preferences.Key<T>,
+        defaultValue: T,
+    ): Flow<T> {
+        return datastore.data.map {
+            it[preferenceKey] ?: defaultValue
+        }
+    }
+
+    /**
+     * stores or updates the value from preferences datastore
+     * @param preferenceKey - key value assigned to be updated
+     */
+    suspend fun <T> store(
+        preferenceKey: Preferences.Key<T>,
+        value: T,
+    ) {
+        datastore.edit {
+            it[preferenceKey] = value
+        }
+    }
+
+    /**
+     * Clears up the value from preferences datastore
+     * @param preferenceKey - key value assigned to be cleared
+     */
+    suspend fun <T> clear(preferenceKey: Preferences.Key<T>) {
+        datastore.edit {
+            if (it.contains(preferenceKey)) it.remove(preferenceKey)
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.22" apply false
     id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
 
-    id("com.google.dagger.hilt.android") version "2.48.1" apply false
+    id("com.google.dagger.hilt.android") version "2.51" apply false
     id("org.jlleitschuh.gradle.ktlint") version "12.1.0" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.5" apply false
     id("de.mannodermaus.android-junit5") version "1.9.3.0" apply false

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -127,7 +127,7 @@ complexity:
     threshold: 60
   LongParameterList:
     active: true
-    functionThreshold: 6
+    functionThreshold: 20
     constructorThreshold: 7
     ignoreDefaultParameters: false
     ignoreDataClasses: true


### PR DESCRIPTION
- add preference datastore dependency in app's build.gradle.kts
- add preference datastore manager class util and provide reusable methods for preferences related stuff
- add data source class for preferences datastore utilization
- add repository class for preferences datastore for presentation layer utilization
- add dependency modules for preferences datastore's data source and repository abstractions
- implement state hoisting and determine what composable widgets should be stateful and stateless
- update static analysis rules mainly for ktlint and detekt to configure based on common accepted flow for Compose related stuff