### PR TITLE
Chore: update dependencies to latest supported versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ val localProperties = Properties()
 localProperties.load(project.rootProject.file("local.properties").inputStream())
 
 // Dependencies Extensions - this will be migrated via version catalog
-val composeVersion = "1.6.3"
+val composeVersion = "1.6.6"
 val roomVersion = "2.6.0"
 val hiltVersion = "2.51"
 
@@ -116,7 +116,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.9"
+        kotlinCompilerExtensionVersion = "1.5.12"
     }
 
     packaging {
@@ -156,14 +156,14 @@ dependencies {
     // Splash Screen
     implementation("androidx.core:core-splashscreen:1.0.1")
 
-    implementation("androidx.activity:activity-ktx:1.8.2")
-    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation("androidx.activity:activity-ktx:1.9.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
 
     // Navigation Compose
     implementation("androidx.navigation:navigation-compose:2.7.7")
 
     // Preferences Datastore
-    implementation("androidx.datastore:datastore-preferences:1.0.0")
+    implementation("androidx.datastore:datastore-preferences:1.1.0")
 
     // Hilt dependencies
     implementation("com.google.dagger:hilt-android:$hiltVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ buildscript {
 plugins {
     id("com.android.application") version "8.2.2" apply false
     id("com.android.library") version "8.2.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
-    id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id("com.google.devtools.ksp") version "1.9.23-1.0.20" apply false
 
     id("com.google.dagger.hilt.android") version "2.51" apply false
     id("org.jlleitschuh.gradle.ktlint") version "12.1.0" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.nonTransitiveRClass=true
 
 # Use latest lint alpha for best available K2 support
 # https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
-android.experimental.lint.version=8.4.0-alpha10
+android.experimental.lint.version=8.5.0-alpha06
 
 # Use K2 compiler
 # Updated to stable release once available


### PR DESCRIPTION
- update compose general dependency version from 1.6.3 to 1.6.6
- update kotlinCompilerExtensionVersion from 1.5.9 to 1.5.12
- update androidx activity related package from 1.8.2 to 1.9.0
- update preferences datastore version from 1.0.0 to 1.1.0
- update kotlin version from 1.9.22 to 1.9.23 to cope up with version update of kotlinCompilerExtensionVersion
- update ksp version from 1.9.22-1.0.17 to 1.9.23-1.0.20 to cope up with version update of kotlin 1.9.23
- update k2 lint support to 8.5.0-alpha06