### PR TITLE
Test: add unit tests for onboarding process implementation

### DIFF
--- a/app/src/main/java/com/dailyscoop/app/MainActivity.kt
+++ b/app/src/main/java/com/dailyscoop/app/MainActivity.kt
@@ -35,11 +35,11 @@ class MainActivity : ComponentActivity() {
                 is MainUiState.Loading -> {} // Idle state, no need to show something for now
                 is MainUiState.Success -> {
                     val userPreferencesState = (mainUiState.value as MainUiState.Success).userPreferencesData
-                    val shouldShowBottomBar = userPreferencesState.shouldShowBottomBar
+                    val isAppFirstLaunch = userPreferencesState.isAppFirstLaunch
 
                     DailyScoopTheme {
                         val mainNavController = rememberNavController()
-                        val appEntryStartDestination = if (shouldShowBottomBar) ONBOARDING_ROUTE else HOME_ROUTE
+                        val appEntryStartDestination = if (isAppFirstLaunch) ONBOARDING_ROUTE else HOME_ROUTE
 
                         DailyScoopApp(
                             navController = mainNavController,

--- a/app/src/main/java/com/dailyscoop/app/MainVM.kt
+++ b/app/src/main/java/com/dailyscoop/app/MainVM.kt
@@ -27,7 +27,7 @@ class MainVM @Inject constructor(
     val mainUiState: StateFlow<MainUiState> =
         userPreferencesRepository.getIsAppFirstLaunch().map {
             MainUiState.Success(
-                UserPreferencesData(shouldShowBottomBar = it),
+                UserPreferencesData(isAppFirstLaunch = it),
             )
         }.stateIn(
             scope = viewModelScope,

--- a/app/src/main/java/com/dailyscoop/app/core/model/UserPreferencesData.kt
+++ b/app/src/main/java/com/dailyscoop/app/core/model/UserPreferencesData.kt
@@ -4,5 +4,5 @@ package com.dailyscoop.app.core.model
  * Class which contains user preferences data
  */
 data class UserPreferencesData(
-    val shouldShowBottomBar: Boolean,
+    val isAppFirstLaunch: Boolean,
 )

--- a/app/src/test/java/com/dailyscoop/app/datastore/UserPreferencesDatastoreTest.kt
+++ b/app/src/test/java/com/dailyscoop/app/datastore/UserPreferencesDatastoreTest.kt
@@ -1,0 +1,43 @@
+package com.dailyscoop.app.datastore
+
+import app.cash.turbine.test
+import com.dailyscoop.app.data.source.datastore.IUserPreferencesDatastore
+import com.dailyscoop.app.fake.datastore.FakeUserPreferencesDatastore
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UserPreferencesDatastoreTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val testScope = TestScope(UnconfinedTestDispatcher())
+
+    private lateinit var userPreferencesDatastore: IUserPreferencesDatastore
+
+    @BeforeEach
+    fun setup() {
+        userPreferencesDatastore = FakeUserPreferencesDatastore()
+    }
+
+    @Test
+    fun `getIsAppFirstLaunch should retrieve (true) as IS_APP_FIRST_LAUNCH initial value when performed`() =
+        testScope.runTest {
+            userPreferencesDatastore.getIsAppFirstLaunch().test {
+                val isAppFirstLaunch = awaitItem()
+                assertThat(isAppFirstLaunch).isTrue()
+            }
+        }
+
+    @Test
+    fun `getIsAppFirstLaunch should retrieve IS_APP_FIRST_LAUNCH new value when setIsAppFirstLaunch is performed`() =
+        testScope.runTest {
+            userPreferencesDatastore.setIsAppFirstLaunch(false)
+            userPreferencesDatastore.getIsAppFirstLaunch().test {
+                val isAppFirstLaunch = awaitItem()
+                assertThat(isAppFirstLaunch).isFalse()
+            }
+        }
+}

--- a/app/src/test/java/com/dailyscoop/app/fake/datastore/FakeUserPreferencesDatastore.kt
+++ b/app/src/test/java/com/dailyscoop/app/fake/datastore/FakeUserPreferencesDatastore.kt
@@ -1,0 +1,31 @@
+package com.dailyscoop.app.fake.datastore
+
+import com.dailyscoop.app.core.model.UserPreferencesData
+import com.dailyscoop.app.data.source.datastore.IUserPreferencesDatastore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.update
+
+class FakeUserPreferencesDatastore : IUserPreferencesDatastore {
+    private val userPreferencesData =
+        MutableStateFlow(
+            UserPreferencesData(
+                isAppFirstLaunch = true,
+            ),
+        )
+
+    override suspend fun setIsAppFirstLaunch(value: Boolean) {
+        userPreferencesData.update {
+            it.copy(isAppFirstLaunch = value)
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    override fun getIsAppFirstLaunch(): Flow<Boolean> {
+        return userPreferencesData.mapLatest {
+            it.isAppFirstLaunch
+        }
+    }
+}

--- a/app/src/test/java/com/dailyscoop/app/fake/repository/FakeUserPreferencesRepository.kt
+++ b/app/src/test/java/com/dailyscoop/app/fake/repository/FakeUserPreferencesRepository.kt
@@ -2,16 +2,14 @@ package com.dailyscoop.app.fake.repository
 
 import com.dailyscoop.app.data.repositories.IUserPreferencesRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 
-/**
- * TO-DO: Complete the implementation for this fake user preferences repository object
- */
 class FakeUserPreferencesRepository : IUserPreferencesRepository {
     @Suppress("EmptyFunctionBlock")
-    override suspend fun setIsAppFirstLaunch(value: Boolean) {}
+    override suspend fun setIsAppFirstLaunch(value: Boolean) {
+    }
 
     override fun getIsAppFirstLaunch(): Flow<Boolean> {
-        return flow { true }
+        return flowOf(true)
     }
 }

--- a/app/src/test/java/com/dailyscoop/app/repository/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/dailyscoop/app/repository/UserPreferencesRepositoryTest.kt
@@ -1,0 +1,49 @@
+package com.dailyscoop.app.repository
+
+import app.cash.turbine.test
+import com.dailyscoop.app.data.repositories.IUserPreferencesRepository
+import com.dailyscoop.app.data.repositories.UserPreferencesRepository
+import com.dailyscoop.app.data.source.datastore.IUserPreferencesDatastore
+import com.dailyscoop.app.fake.datastore.FakeUserPreferencesDatastore
+import com.google.common.truth.Truth
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserPreferencesRepositoryTest {
+    private val testScope = TestScope(UnconfinedTestDispatcher())
+
+    private lateinit var userPreferencesDatastore: IUserPreferencesDatastore
+
+    private lateinit var userPreferencesRepository: IUserPreferencesRepository
+
+    @BeforeEach
+    fun setup() {
+        userPreferencesDatastore = FakeUserPreferencesDatastore()
+
+        userPreferencesRepository = UserPreferencesRepository(userPreferencesDatastore)
+    }
+
+    @Test
+    fun `getIsAppFirstLaunch should retrieve (true) as IS_APP_FIRST_LAUNCH preference key's value when initialized`() =
+        testScope.runTest {
+            userPreferencesRepository.getIsAppFirstLaunch().test {
+                val isAppFirstLaunch = awaitItem()
+                Truth.assertThat(isAppFirstLaunch).isTrue()
+            }
+        }
+
+    @Test
+    fun `getIsAppFirstLaunch should retrieve IS_APP_FIRST_LAUNCH new value when setIsAppFirstLaunch() is performed`() =
+        testScope.runTest {
+            userPreferencesRepository.setIsAppFirstLaunch(false)
+            userPreferencesRepository.getIsAppFirstLaunch().test {
+                val isAppFirstLaunch = awaitItem()
+                Truth.assertThat(isAppFirstLaunch).isFalse()
+            }
+        }
+}

--- a/app/src/test/java/com/dailyscoop/app/viewmodel/MainVMTest.kt
+++ b/app/src/test/java/com/dailyscoop/app/viewmodel/MainVMTest.kt
@@ -1,8 +1,10 @@
 package com.dailyscoop.app.viewmodel
 
 import com.dailyscoop.app.ArticleUiState
+import com.dailyscoop.app.MainUiState
 import com.dailyscoop.app.MainVM
 import com.dailyscoop.app.NewsUiState
+import com.dailyscoop.app.core.model.UserPreferencesData
 import com.dailyscoop.app.data.repositories.INewsRepository
 import com.dailyscoop.app.data.repositories.IUserPreferencesRepository
 import com.dailyscoop.app.fake.repository.FakeNewsRepository
@@ -39,29 +41,49 @@ class MainVMTest {
     }
 
     @Test
-    fun newsUiState_whenInitialized_thenShowLoading() =
+    fun `mainUiState should retrieve (MainUiState_Loading) state value when initialized`() =
+        runTest {
+            assertThat(viewModel.mainUiState.value).isEqualTo(MainUiState.Loading)
+        }
+
+    @Test
+    fun `mainUiState should retrieve (MainUiState_Success) state value when getIsAppFirstLaunch() is performed`() =
+        runTest {
+            val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.mainUiState.collect() }
+
+            val isAppFirstLaunch = userPreferencesRepository.getIsAppFirstLaunch().first()
+            val userPreferencesData = UserPreferencesData(isAppFirstLaunch = isAppFirstLaunch)
+
+            assertThat(userPreferencesData.isAppFirstLaunch).isTrue()
+            assertThat(viewModel.mainUiState.value).isEqualTo(MainUiState.Success(userPreferencesData))
+
+            collectJob.cancel()
+        }
+
+    @Test
+    fun `newsUiState should retrieve (NewsUiState_Loading) state value when initialized`() =
         runTest {
             assertThat(viewModel.newsUiState.value).isEqualTo(NewsUiState.Loading)
         }
 
     @Test
-    fun articleUiState_whenInitialized_thenShowLoading() =
+    fun `articleUiState should retrieve (ArticleUiState_Loading) state value when initialized`() =
         runTest {
             assertThat(viewModel.articleUiState.value).isEqualTo(ArticleUiState.Loading)
         }
 
     @Test
-    fun articleUiState_whenSuccess_matchesHeadlinesFromNewsRepository() =
+    fun `articleUiState should retrieve (ArticleUiState_Success) state value when getArticleInfo() is performed`() =
         runTest {
             val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.articleUiState.collect() }
 
-            val articleInfoFromRepository =
+            val newsArticle =
                 newsRepository.getArticleInfo(
                     newsId = 2,
                     externalId = "57fe599411e31393e29111b6510c8460",
                 ).first()
 
-            assertThat(viewModel.articleUiState.value).isEqualTo(ArticleUiState.Success(articleInfoFromRepository))
+            assertThat(viewModel.articleUiState.value).isEqualTo(ArticleUiState.Success(newsArticle))
 
             collectJob.cancel()
         }


### PR DESCRIPTION
- add necessary test doubles through fakes such as: FakeUserPreferencesDatastore.kt & FakeUserPreferencesRepository.kt
- rename shouldShowBottomBar to isAppFirstLaunch in UserPreferencesData.kt
- add necessary test files for user preferences related implementations of its datastore, repository and affected vm

![Screenshot 2024-06-25 at 9 22 55 AM](https://github.com/shawn-mperfinan/daily-scoop-android/assets/108687438/6d575754-7c6c-41f7-a69e-ea7f60efc39e)
