### PR TITLE
Feature: upgrade to Android 15 and utilize Version Catalog

### DIFF
--- a/.github/workflows/build_deployment.yml
+++ b/.github/workflows/build_deployment.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - name: Set up Ruby and Bundler
         uses: ruby/setup-ruby@v1
@@ -29,6 +29,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
+          gradle-version: 8.11.1
           cache-disabled: true
 
       - name: Set up Encrypted Keystore File

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -15,16 +15,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.1
+          gradle-version: 8.11.1
           cache-read-only: false
 
       - name: Set up Encrypted Keystore File

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,40 +1,50 @@
 import java.util.Properties
 
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("com.google.devtools.ksp")
-    id("dagger.hilt.android.plugin")
-    id("de.mannodermaus.android-junit5")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.android.kotlin)
+    alias(libs.plugins.devtools.ksp)
+    alias(libs.plugins.android.hilt)
+    alias(libs.plugins.android.junit5)
+    alias(libs.plugins.compose.plugin)
 }
 
 // Initialize for property retrieval on variables defined in [local.properties]
 val localProperties = Properties()
 localProperties.load(project.rootProject.file("local.properties").inputStream())
 
-// Dependencies Extensions - this will be migrated via version catalog
-val composeVersion = "1.6.6"
-val roomVersion = "2.6.0"
-val hiltVersion = "2.51"
+// Calculates and get the versionCode based on commit counts
+fun getVersionCode(): Int {
+    // Run the Git command and get the commit count result as an integer
+    val commitCount =
+        providers.exec {
+            commandLine("git", "rev-list", "--no-merges", "--count", "HEAD")
+        }.standardOutput.asText.get().trim().toInt()
+
+    // kindly refer to the current value of versionName based on its MAJOR, MINOR and PATCH value then append 000
+    // current value --> versionName = 1.0.0
+    val semanticVersionCombination = 100000
+
+    return commitCount + semanticVersionCombination
+}
 
 android {
 
     namespace = "com.dailyscoop.app"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
 
         applicationId = "com.dailyscoop.app"
 
-        // TODO: update this to 28, therefore Android Pie will be the minimum os version soon
-        minSdk = 27
+        minSdk = 31
 
-        targetSdk = 34
-
-        versionCode = getVersionCode()
+        targetSdk = 35
 
         versionName = "1.0.0"
+
+        versionCode = getVersionCode()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["runnerBuilder"] = "de.mannodermaus.junit5.AndroidJUnit5Builder"
@@ -56,6 +66,27 @@ android {
         }
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(JavaVersion.VERSION_21.toString())
+        }
+    }
+
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
+
+    lint {
+        checkReleaseBuilds = false
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+
     signingConfigs {
         create("release") {
             storeFile = file("../release/dailyscoop-keystore.jks")
@@ -69,7 +100,6 @@ android {
     productFlavors {
         create("dev") {
             dimension = "type"
-            versionName = "1.0.0-dev"
             buildConfigField("String", "NEWS_API_KEY", "\"${localProperties.getProperty("NEWS_API_KEY")}\"")
         }
 
@@ -97,122 +127,76 @@ android {
         }
     }
 
-    lint {
-        checkReleaseBuilds = false
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
-    buildFeatures {
-        compose = true
-        buildConfig = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.12"
-    }
-
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
-
     // TODO: configure testOptions for junit5
 }
 
-// Calculates and get the versionCode based on commit counts
-@Suppress("UnstableApiUsage")
-fun getVersionCode(): Int {
-    // Run the Git command and get the commit count result as an integer
-    val commitCount =
-        providers.exec {
-            commandLine("git", "rev-list", "--no-merges", "--count", "HEAD")
-        }.standardOutput.asText.get().trim().toInt()
-
-    // kindly refer to the current value of versionName based on its MAJOR, MINOR and PATCH value then append 000
-    // current value --> versionName = 1.0.0
-    val semanticVersionCombination = 100000
-
-    return commitCount + semanticVersionCombination
-}
-
 dependencies {
-    implementation("androidx.compose.ui:ui:$composeVersion")
-    implementation("androidx.compose.material3:material3:1.2.1")
-    implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
-    // TODO: this will be needed in order to support multiple screen densities
-    // implementation "androidx.compose.material3:material3-window-size-class:1.1.1"
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.tooling.preview)
+
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     // Splash Screen
-    implementation("androidx.core:core-splashscreen:1.0.1")
+    implementation(libs.androidx.core.splashscreen)
 
-    implementation("androidx.activity:activity-ktx:1.9.0")
-    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation(libs.androidx.activity.ktx)
+    implementation(libs.androidx.activity.compose)
 
     // Navigation Compose
-    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation(libs.androidx.navigation.compose)
 
     // Preferences Datastore
-    implementation("androidx.datastore:datastore-preferences:1.1.0")
+    implementation(libs.androidx.datastore.preferences)
 
     // Hilt dependencies
-    implementation("com.google.dagger:hilt-android:$hiltVersion")
-    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
-    ksp("com.google.dagger:hilt-android-compiler:$hiltVersion")
+    implementation(libs.google.dagger.hilt.android)
+    implementation(libs.androidx.hilt.navigation.compose)
+    ksp(libs.google.dagger.hilt.android.compiler)
 
     // Retrofit
-    implementation("com.squareup.retrofit2:retrofit:2.9.0") // latest is 2.11.0
-    implementation("com.squareup.retrofit2:converter-gson:2.9.0") // latest is 2.11.0
-    implementation("com.google.code.gson:gson:2.10.1")
-    implementation("com.squareup.okhttp3:logging-interceptor:4.10.0") // latest is 4.12.0
+    implementation(libs.squareup.retrofit2)
+    implementation(libs.squareup.retrofit2.converter.gson)
+    implementation(libs.google.gson)
+    implementation(libs.squareup.okhttp3.logging.interceptor)
 
     // Room
-    implementation("androidx.room:room-ktx:$roomVersion")
-    implementation("androidx.room:room-runtime:$roomVersion")
-    implementation("androidx.room:room-paging:$roomVersion")
-    ksp("androidx.room:room-compiler:$roomVersion")
+    implementation(libs.androidx.room.ktx)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.paging)
+    ksp(libs.androidx.room.compiler)
 
     // MockWebserver
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation(libs.squareup.okhttp3.mockwebserver)
 
     // Writing and executing Unit Tests on the JUnit 5 Platform
     // Stay tuned for official google android support for JUnit 5
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
 
     // Needed for unit testing
-    testImplementation("androidx.arch.core:core-testing:2.2.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    testImplementation(libs.androidx.core.testing)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     // Room test helpers
-    testImplementation("androidx.room:room-testing:$roomVersion")
+    testImplementation(libs.androidx.room.testing)
 
     // Test Assertion
-    testImplementation("com.google.truth:truth:1.4.2")
+    testImplementation(libs.google.truth)
 
     // Turbine
-    testImplementation("app.cash.turbine:turbine:1.1.0")
+    testImplementation(libs.app.cash.turbine)
 
     // JUnit 5 instrumentation test dependencies
-    androidTestImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
-    androidTestImplementation("de.mannodermaus.junit5:android-test-core:1.3.0")
-    androidTestRuntimeOnly("de.mannodermaus.junit5:android-test-runner:1.3.0")
+    androidTestImplementation(libs.junit.jupiter.api)
+    androidTestImplementation(libs.junit5.android.test.core)
+    androidTestRuntimeOnly(libs.junit5.android.test.runner)
 
-    androidTestImplementation("androidx.test:runner:1.5.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.test.compose.ui.junit4)
 
-    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
+    debugImplementation(libs.androidx.test.compose.ui.tooling)
+    debugImplementation(libs.androidx.test.compose.ui.manifest)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,15 +7,16 @@ buildscript {
 } // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.2.2" apply false
-    id("com.android.library") version "8.2.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
-    id("com.google.devtools.ksp") version "1.9.23-1.0.20" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.android.kotlin) apply false
+    alias(libs.plugins.devtools.ksp) apply false
 
-    id("com.google.dagger.hilt.android") version "2.51" apply false
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.0" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.23.5" apply false
-    id("de.mannodermaus.android-junit5") version "1.10.0.0" apply false
+    alias(libs.plugins.android.hilt) apply false
+    alias(libs.plugins.compose.plugin) apply false
+    alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.android.junit5) apply false
 }
 
 // TODO: migrate this to allProjects once modularization is implemented

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,14 +33,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-
-# Use latest lint alpha for best available K2 support
-# https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
-android.experimental.lint.version=8.5.0-alpha06
-
-# Use K2 compiler
-# Updated to stable release once available
-kotlin.experimental.tryK2=true
-
-# Run lint on K2
-android.lint.useK2Uast=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,100 @@
+[versions]
+
+# AGP and Tools
+androidGradlePlugin = "8.9.1"
+kotlin = "2.1.20"
+devtoolsKsp = "2.1.20-1.0.32"
+
+# Static Code Analyzer
+ktLint = "12.2.0"
+detekt = "1.23.8"
+androidJUnit5 = "1.12.0.0"
+
+# AndroidX
+composeMaterial3 = "1.3.2"
+coreSplashscreen = "1.0.1"
+composeToolingPreview = "1.7.8"
+composeLifecycle = "2.8.7"
+activity = "1.10.1"
+navigationCompose = "2.8.9"
+datastorePreferences = "1.1.4"
+hiltNavigationCompose = "1.2.0"
+room = "2.7.0"
+testRunner = "1.6.2"
+testExtJUnit = "1.2.1"
+testEspressoCore = "3.6.1"
+testComposeUi = "1.7.8"
+
+# Google
+hiltAndroid = "2.51.1"
+truth = "1.4.2"
+
+# Http
+retrofit = "2.11.0"
+loggingInterceptor = "4.10.0"
+mockWebServer = "4.12.0"
+
+# Testing
+junitJupiter = "5.12.0"
+coreTesting = "2.2.0"
+kotlinxCoroutinesTest = "1.8.1"
+turbine = "1.1.0"
+junit5AndroidTest = "1.7.0"
+
+[plugins]
+
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+android-kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "devtoolsKsp" }
+android-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hiltAndroid" }
+compose-plugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktLint" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "androidJUnit5" }
+
+[libraries]
+
+# AndroidX
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "composeMaterial3" }
+androidx-compose-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "composeToolingPreview" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "composeLifecycle" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "composeLifecycle" }
+androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "coreTesting" }
+androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "testRunner" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "testExtJUnit" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "testEspressoCore" }
+androidx-test-compose-ui-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "testComposeUi" }
+androidx-test-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "testComposeUi" }
+androidx-test-compose-ui-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "testComposeUi" }
+
+# Google
+google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltAndroid" }
+google-dagger-hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hiltAndroid" }
+google-truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+
+# Http
+squareup-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+squareup-retrofit2-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+squareup-okhttp3-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "loggingInterceptor" }
+squareup-okhttp3-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockWebServer" }
+google-gson = { group = "com.google.code.gson", name = "gson", version.ref = "retrofit" }
+
+# Testing
+junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junitJupiter" }
+junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitJupiter" }
+junit5-android-test-core = { group = "de.mannodermaus.junit5", name = "android-test-core", version.ref = "junit5AndroidTest" }
+junit5-android-test-runner = { group = "de.mannodermaus.junit5", name = "android-test-runner", version.ref = "junit5AndroidTest" }
+app-cash-turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 05 02:03:18 PST 2022
+#Tue Apr 08 09:56:46 PST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,6 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "Daily Scoop"
+rootProject.name = "dailyscoop"
 
 include(":app")


### PR DESCRIPTION
- implement and utilize version catalog
- set minSdk to Android 12 (31)
- set targetSdk and compileSdk to Android 15 (35)
- upgrade kotlin version and gradle plugin
- remove experimental trigger for K2 Compiler since it's now enabled by default via Kotlin 2.x.x
- update rootProject.name to "dailyscoop"