### PR TITLE
Chore: upgrade several plugins

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # AGP and Tools
-androidGradlePlugin = "8.9.1"
+androidGradlePlugin = "8.9.2"
 kotlin = "2.1.20"
 devtoolsKsp = "2.1.20-1.0.32"
 
@@ -13,35 +13,35 @@ androidJUnit5 = "1.12.0.0"
 # AndroidX
 composeMaterial3 = "1.3.2"
 coreSplashscreen = "1.0.1"
-composeToolingPreview = "1.7.8"
+composeToolingPreview = "1.8.0"
 composeLifecycle = "2.8.7"
 activity = "1.10.1"
 navigationCompose = "2.8.9"
 datastorePreferences = "1.1.4"
 hiltNavigationCompose = "1.2.0"
-room = "2.7.0"
+room = "2.7.1"
 testRunner = "1.6.2"
 testExtJUnit = "1.2.1"
 testEspressoCore = "3.6.1"
-testComposeUi = "1.7.8"
+testComposeUi = "1.8.0"
 
 # Jetbrains
 kotlinxSerialization = "1.8.0"
 
 # Google
-hiltAndroid = "2.51.1"
-truth = "1.4.2"
+hiltAndroid = "2.56"
+truth = "1.4.4"
 
 # Http
 retrofit = "2.11.0"
-loggingInterceptor = "4.10.0"
+loggingInterceptor = "4.12.0"
 mockWebServer = "4.12.0"
 
 # Testing
 junitJupiter = "5.12.0"
 coreTesting = "2.2.0"
-kotlinxCoroutinesTest = "1.8.1"
-turbine = "1.1.0"
+kotlinxCoroutinesTest = "1.10.1"
+turbine = "1.2.0"
 junit5AndroidTest = "1.7.0"
 
 [plugins]


### PR DESCRIPTION
- androidGradlePlugin to 8.9.2
- composeToolingPreview to 1.8.0
- room to 2.7.1
- testComposeUi to 1.8.0
- hiltAndroid to 2.56
- truth to 1.4.4
- loggingInterceptor to 4.12.0
- kotlinxCoroutinesTest to 1.10.1
- turbine to 1.2.0